### PR TITLE
Adding time into logger

### DIFF
--- a/library/logger/logger.cc
+++ b/library/logger/logger.cc
@@ -191,7 +191,7 @@ namespace scarab
             fPrivate->fLogger = logName;
         }
         fPrivate->fColored = true;
-        sprintf(logger::Private::sDateTimeFormat,  "%%m/%%d/%%y %%T");
+        sprintf(logger::Private::sDateTimeFormat,  "%%y-%%m-%%d %%T");
         SetLevel(eDebug);
         logger::Private::AllLoggers()->insert(this);
     }
@@ -200,7 +200,7 @@ namespace scarab
     {
         fPrivate->fLogger = name.c_str();
         fPrivate->fColored = true;
-		sprintf(logger::Private::sDateTimeFormat, "%%m/%%d/%%y %%T");
+		sprintf(logger::Private::sDateTimeFormat, "%%y-%%m-%%d %%T");
 		SetLevel(eDebug);
 		logger::Private::AllLoggers()->insert(this);
     }

--- a/library/logger/logger.cc
+++ b/library/logger/logger.cc
@@ -191,7 +191,7 @@ namespace scarab
             fPrivate->fLogger = logName;
         }
         fPrivate->fColored = true;
-        sprintf(logger::Private::sDateTimeFormat,  "%%y-%%m-%%d %%T");
+        sprintf(logger::Private::sDateTimeFormat,  "%%Y-%%m-%%d %%T");
         SetLevel(eDebug);
         logger::Private::AllLoggers()->insert(this);
     }
@@ -200,7 +200,7 @@ namespace scarab
     {
         fPrivate->fLogger = name.c_str();
         fPrivate->fColored = true;
-		sprintf(logger::Private::sDateTimeFormat, "%%y-%%m-%%d %%T");
+		sprintf(logger::Private::sDateTimeFormat, "%%Y-%%m-%%d %%T");
 		SetLevel(eDebug);
 		logger::Private::AllLoggers()->insert(this);
     }

--- a/library/logger/logger.cc
+++ b/library/logger/logger.cc
@@ -191,7 +191,7 @@ namespace scarab
             fPrivate->fLogger = logName;
         }
         fPrivate->fColored = true;
-        sprintf(logger::Private::sDateTimeFormat,  "%%T");
+        sprintf(logger::Private::sDateTimeFormat,  "%%m/%%d/%%y %%T");
         SetLevel(eDebug);
         logger::Private::AllLoggers()->insert(this);
     }
@@ -200,7 +200,7 @@ namespace scarab
     {
         fPrivate->fLogger = name.c_str();
         fPrivate->fColored = true;
-		sprintf(logger::Private::sDateTimeFormat, "%%T");
+		sprintf(logger::Private::sDateTimeFormat, "%%m/%%d/%%y %%T");
 		SetLevel(eDebug);
 		logger::Private::AllLoggers()->insert(this);
     }


### PR DESCRIPTION
Solving part of  https://github.com/project8/scarab/issues/17

Will print logs with the date (month/day/year) as
```11/06/17 17:44:08 [DEBUG] (tid 0x7fffe09553c0) ility/factory.hh(210): Registered a factory for class json at 0x1097cdff0, factory #0 for 0x7fb5b0403580```