### PR TITLE
Allowing not to build param: this will clean up any logger of any lib…

### DIFF
--- a/documentation/cpp/Scarab_LibraryOverview.rst
+++ b/documentation/cpp/Scarab_LibraryOverview.rst
@@ -1,2 +1,39 @@
 Scarab/Library Overview
 =======================
+
+* Utilities
+* Logger
+* Param
+
+  * Core Param classes
+  * Codecs for translation to/from various data-storage standards
+  * Application configuration
+
+* Authentication
+
+Build Options
+-------------
+
+* Scarab_BUILD_PARAM 
+ 
+  * Build the core param and application configuration classes
+
+* Scarab_BUILD_CODEC_JSON
+
+  * Build the JSON codec
+  * Requires Scarab_BUILD_PARAM
+
+* Scarab_BUILD_CODEC_YAML
+
+  * Build the YAML codec
+  * Requires Scarab_BUILD_PARAM
+
+* Scarab_BUILD_CODEC_MSGPACK
+
+  * Build the MSGPACK codec
+  * Requires Scarab_BUILD_PARAM
+
+* Scarab_BUILD_AUTHENTICATION
+
+  * Build the authentication class 
+  * Requires Scarab_BUILD_PARAM and Scarab_BUILD_CODEC_JSON

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -37,13 +37,6 @@ option( Scarab_BUILD_AUTHENTICATION "Flag to enable building of the authenticati
 
 option( Scarab_BUILD_PARAM "Flag to enable building of the param class" TRUE )
 
-if (NOT Scarab_BUILD_PARAM)
-    set( Scarab_BUILD_AUTHENTICATION OFF)
-    set( Scarab_BUILD_CODEC_JSON OFF)
-    set( Scarab_BUILD_CODEC_YAML OFF)
-    set( Scarab_BUILD_CODEC_MSGPACK OFF)
-endif (NOT Scarab_BUILD_PARAM)
-
 if (Scarab_BUILD_AUTHENTICATION)
     set(Scarab_BUILD_CODEC_JSON ON)
 endif (Scarab_BUILD_AUTHENTICATION)
@@ -106,11 +99,6 @@ if( Scarab_BUILD_AUTHENTICATION )
     list( APPEND boost_components filesystem system )
 endif( Scarab_BUILD_AUTHENTICATION )
 
-if( Scarab_BUILD_PARAM )
-    include_directories( BEFORE ${PROJECT_SOURCE_DIR}/param )
-    add_subdirectory( param )
-endif( Scarab_BUILD_PARAM )
-
 list( APPEND boost_components filesystem system )
 
 # making sure boost_components is not empty and remove duplicate
@@ -156,10 +144,15 @@ set( Scarab_SOURCES )
 add_subdirectory( utility )
 add_subdirectory( logger )
 
-if( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_AUTHENTICATION )
+if( Scarab_BUILD_PARAM )
+    include_directories( BEFORE ${PROJECT_SOURCE_DIR}/param )
+    add_subdirectory( param )
+endif( Scarab_BUILD_PARAM )
+
+if( Scarab_BUILD_CODEC_JSON )
     include_directories( BEFORE ${PROJECT_SOURCE_DIR}/param/codec/json )
     add_subdirectory( param/codec/json )
-endif( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_AUTHENTICATION )
+endif( Scarab_BUILD_CODEC_JSON )
 
 if( Scarab_BUILD_CODEC_MSGPACK )
     include_directories( BEFORE ${PROJECT_SOURCE_DIR}/param/codec/msgpack )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -37,12 +37,26 @@ option( Scarab_BUILD_AUTHENTICATION "Flag to enable building of the authenticati
 
 option( Scarab_BUILD_PARAM "Flag to enable building of the param class" TRUE )
 
+if (NOT Scarab_BUILD_PARAM)
+    set( Scarab_BUILD_AUTHENTICATION OFF)
+    set( Scarab_BUILD_CODEC_JSON OFF)
+    set( Scarab_BUILD_CODEC_YAML OFF)
+    set( Scarab_BUILD_CODEC_MSGPACK OFF)
+endif (NOT Scarab_BUILD_PARAM)
+
+if (Scarab_BUILD_AUTHENTICATION)
+    set(Scarab_BUILD_CODEC_JSON ON)
+endif (Scarab_BUILD_AUTHENTICATION)
+
+if (Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_CODEC_MSGPACK OR Scarab_BUILD_CODEC_YAML)
+    set( Scarab_BUILD_PARAM ON)
+endif ( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_CODEC_MSGPACK OR Scarab_BUILD_CODEC_YAML)
 
 #######################
 # Scarab dependencies #
 #######################
 
-if( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_AUTHENTICATION )
+if( Scarab_BUILD_CODEC_JSON )
 	# filesystem and system for param_value's use of boost::filesystem::path
 	# thread and date_time for concurrent_queue
 	set( boost_components filesystem system thread date_time )
@@ -61,7 +75,7 @@ if( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_AUTHENTICATION )
     
     add_subdirectory( param/codec/json/rapidjson )
     include_directories( BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/param/codec/json/rapidjson/include/ )
-endif( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_AUTHENTICATION )
+endif( Scarab_BUILD_CODEC_JSON )
 
 if( Scarab_BUILD_CODEC_MSGPACK )
     # msgpack-c

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -27,23 +27,23 @@ pbuilder_prepare_project()
 # Scarab options #
 ##################
 
-option( Scarab_BUILD_CODEC_JSON "Flag to enable building the JSON codec" TRUE )
+option( Scarab_BUILD_CODEC_JSON "Flag to enable building the JSON codec (requires Scarab_BUILD_PARAM)" TRUE )
 
-option( Scarab_BUILD_CODEC_MSGPACK "Flag to enable building the msgpack codec" FALSE )
+option( Scarab_BUILD_CODEC_MSGPACK "Flag to enable building the MSGPACK codec (requires Scarab_BUILD_PARAM)" FALSE )
 
-option( Scarab_BUILD_CODEC_YAML "Flag to enable building the yaml codec" TRUE )
+option( Scarab_BUILD_CODEC_YAML "Flag to enable building the YAML codec (requires Scarab_BUILD_PARAM)" TRUE )
 
-option( Scarab_BUILD_AUTHENTICATION "Flag to enable building of the authentication class (requires boost::filesystem)" TRUE )
+option( Scarab_BUILD_AUTHENTICATION "Flag to enable building of the authentication class (requires Scarab_BUILD_CODEC_JSON)" TRUE )
 
 option( Scarab_BUILD_PARAM "Flag to enable building of the param class" TRUE )
 
-if (Scarab_BUILD_AUTHENTICATION)
-    set(Scarab_BUILD_CODEC_JSON ON)
-endif (Scarab_BUILD_AUTHENTICATION)
+if( (Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_CODEC_MSGPACK OR Scarab_BUILD_CODEC_YAML) AND NOT Scarab_BUILD_PARAM )
+    message( FATAL_ERROR "Invalid combination of build options.  Building the Codecs requires Param.  If you want a Codec, turn on Param.  If you want Param off, turn the Codecs off." )
+endif( (Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_CODEC_MSGPACK OR Scarab_BUILD_CODEC_YAML) AND NOT Scarab_BUILD_PARAM )
 
-if (Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_CODEC_MSGPACK OR Scarab_BUILD_CODEC_YAML)
-    set( Scarab_BUILD_PARAM ON)
-endif ( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_CODEC_MSGPACK OR Scarab_BUILD_CODEC_YAML)
+if( Scarab_BUILD_AUTHENTICATION AND NOT Scarab_BUILD_CODEC_JSON )
+    message( FATAL_ERROR "Invalid combination of build options.  Building Authentication requires the JSON Codec.  If you want Authentication, turn on the JSON Codec.  If you want the JSON Codec off, turn Authentication off.")
+endif( Scarab_BUILD_AUTHENTICATION AND NOT Scarab_BUILD_CODEC_JSON )
 
 #######################
 # Scarab dependencies #

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -35,6 +35,8 @@ option( Scarab_BUILD_CODEC_YAML "Flag to enable building the yaml codec" TRUE )
 
 option( Scarab_BUILD_AUTHENTICATION "Flag to enable building of the authentication class (requires boost::filesystem)" TRUE )
 
+option( Scarab_BUILD_PARAM "Flag to enable building of the param class" TRUE )
+
 
 #######################
 # Scarab dependencies #
@@ -90,6 +92,13 @@ if( Scarab_BUILD_AUTHENTICATION )
     list( APPEND boost_components filesystem system )
 endif( Scarab_BUILD_AUTHENTICATION )
 
+if( Scarab_BUILD_PARAM )
+    include_directories( BEFORE ${PROJECT_SOURCE_DIR}/param )
+    add_subdirectory( param )
+endif( Scarab_BUILD_PARAM )
+
+list( APPEND boost_components filesystem system )
+
 # making sure boost_components is not empty and remove duplicate
 if (boost_components)
     list( REMOVE_DUPLICATES boost_components )
@@ -123,7 +132,6 @@ endif( WIN32 )
 include_directories( BEFORE
     ${PROJECT_SOURCE_DIR}/utility
     ${PROJECT_SOURCE_DIR}/logger
-    ${PROJECT_SOURCE_DIR}/param
 )
 
 ##########
@@ -133,7 +141,6 @@ set( Scarab_SOURCES )
 
 add_subdirectory( utility )
 add_subdirectory( logger )
-add_subdirectory( param )
 
 if( Scarab_BUILD_CODEC_JSON OR Scarab_BUILD_AUTHENTICATION )
     include_directories( BEFORE ${PROJECT_SOURCE_DIR}/param/codec/json )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -65,9 +65,12 @@ if( Scarab_BUILD_CODEC_JSON )
     set( RAPIDJSON_FILE_BUFFER_SIZE 65536 CACHE STRING "Buffer size for reading and writing files using RapidJSON (in Bytes)" )
     
     add_definitions( -DRAPIDJSON_FILE_BUFFER_SIZE=${RAPIDJSON_FILE_BUFFER_SIZE} )
+    add_definitions( -DUSE_CODEC_JSON )
     
     add_subdirectory( param/codec/json/rapidjson )
     include_directories( BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/param/codec/json/rapidjson/include/ )
+else( Scarab_BUILD_CODEC_JSON )
+    remove_definitions( -DUSE_CODEC_JSON )
 endif( Scarab_BUILD_CODEC_JSON )
 
 if( Scarab_BUILD_CODEC_MSGPACK )

--- a/library/param/configurator.cc
+++ b/library/param/configurator.cc
@@ -9,9 +9,12 @@
 
 #include "logger.hh"
 #include "param_codec.hh"
-#include "param_json.hh"
 #include "parser.hh"
 #include "path.hh"
+
+#ifdef USE_CODEC_JSON
+#include "param_json.hh"
+#endif
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
@@ -109,6 +112,7 @@ namespace scarab
         //cout << f_master_config );
         //cout << t_parser );
 
+#ifdef USE_CODEC_JSON
         // third configuration: command line json
         if( t_parser.has( t_name_json ) )
         {
@@ -125,6 +129,7 @@ namespace scarab
                 delete t_config_from_json;
             }
         }
+#endif
 
         //std::cout << "third configuration complete" << std::endl;
         //cout << f_master_config );

--- a/library/test/CMakeLists.txt
+++ b/library/test/CMakeLists.txt
@@ -16,11 +16,22 @@ if( Scarab_ENABLE_TESTING )
     
     set( test_programs
         test__member_variables
-        test_configurator
         test_logger
-        test_yaml
     )
     
+    if( Scarab_BUILD_PARAM )
+        set( test_programs
+            ${test_programs}
+            test_configurator
+        )
+    endif( Scarab_BUILD_PARAM )
+
+    if( Scarab_BUILD_CODEC_YAML )
+        set( test_programs
+            ${test_programs}
+            test_yaml
+        )
+    endif( Scarab_BUILD_CODEC_YAML )
     
     pbuilder_executables( test_programs lib_dependencies )
 


### PR DESCRIPTION
…rary built using scarab (if desired).
Other libraries generally don't use the factories, but codec factories get registered anyway, leading to an useless verbosity.
Adding an option not to build param (which is responsible for this registration) has been added.

Basically, this makes Cicada loading less verbose: from
```
        _                __
  _____(_)________ _____/ /___ _
 / ___/ / ___/ __ `/ __  / __ `/
/ /__/ / /__/ /_/ / /_/ / /_/ /
\___/_/\___/\__,_/\__,_/\__,_/


RooFit v3.60 -- Developed by Wouter Verkerke and David Kirkby
                Copyright (C) 2000-2013 NIKHEF, University of California & Stanford University
                All rights reserved, please read http://roofit.sourceforge.net/license.txt

2018-06-19 18:21:53 [DEBUG] (tid 0x7fff89c61380) ility/factory.hh(210): Registered a factory for class json at 0x1163c9f00, factory #0 for 0x7fc5fd331fc0
2018-06-19 18:21:53 [DEBUG] (tid 0x7fff89c61380) ility/factory.hh(210): Registered a factory for class json at 0x1163c9f28, factory #0 for 0x7fc5fbf5ceb0
2018-06-19 18:21:53 [DEBUG] (tid 0x7fff89c61380) ility/factory.hh(210): Registered a factory for class yaml at 0x1163c9f70, factory #1 for 0x7fc5fd331fc0
2018-06-19 18:21:53 [DEBUG] (tid 0x7fff89c61380) ility/factory.hh(210): Registered a factory for class yaml at 0x1163c9fa0, factory #1 for 0x7fc5fbf5ceb0
```
to 
```
        _                __
  _____(_)________ _____/ /___ _
 / ___/ / ___/ __ `/ __  / __ `/
/ /__/ / /__/ /_/ / /_/ / /_/ /
\___/_/\___/\__,_/\__,_/\__,_/


RooFit v3.60 -- Developed by Wouter Verkerke and David Kirkby
                Copyright (C) 2000-2013 NIKHEF, University of California & Stanford University
                All rights reserved, please read http://roofit.sourceforge.net/license.txt
```