### PR TITLE
cmake's package name needs to match the pybind11 macro name

### DIFF
--- a/library/python/CMakeLists.txt
+++ b/library/python/CMakeLists.txt
@@ -33,9 +33,9 @@ if( Scarab_BUILD_PYTHON )
     configure_file( add_lib_python_path.sh.in add_lib_python_path.sh @ONLY)
     install( FILES ${CMAKE_CURRENT_BINARY_DIR}/add_lib_python_path.sh DESTINATION ${BIN_INSTALL_DIR} )
 
-    pybind11_add_module( py_scarab ${PYBINDING_SOURCEFILES} )
-    target_link_libraries( py_scarab PRIVATE ${FULL_LIB_DEPENDENCIES} ${EXTERNAL_LIBRARIES} )
-    install( TARGETS py_scarab DESTINATION ${LIB_INSTALL_DIR} )
+    pybind11_add_module( scarab ${PYBINDING_SOURCEFILES} )
+    target_link_libraries( scarab PRIVATE ${FULL_LIB_DEPENDENCIES} ${EXTERNAL_LIBRARIES} )
+    install( TARGETS scarab DESTINATION ${LIB_INSTALL_DIR} )
     pbuilder_install_headers( ${PYBINDING_HEADERFILES} )
 
 endif( Scarab_BUILD_PYTHON )

--- a/library/python/CMakeLists.txt
+++ b/library/python/CMakeLists.txt
@@ -33,6 +33,8 @@ if( Scarab_BUILD_PYTHON )
     configure_file( add_lib_python_path.sh.in add_lib_python_path.sh @ONLY)
     install( FILES ${CMAKE_CURRENT_BINARY_DIR}/add_lib_python_path.sh DESTINATION ${BIN_INSTALL_DIR} )
 
+    # Potential point of confusion: the C++ library is "Scarab" and the python library is "scarab"
+    # Other possible naming schemes seemed less desirable, and we'll hopefully avoid confusion with these comments
     pybind11_add_module( scarab ${PYBINDING_SOURCEFILES} )
     target_link_libraries( scarab PRIVATE ${FULL_LIB_DEPENDENCIES} ${EXTERNAL_LIBRARIES} )
     install( TARGETS scarab DESTINATION ${LIB_INSTALL_DIR} )


### PR DESCRIPTION
I made them all scarab, we could make them all py_scarab instead but that would mean you would `import py_scarab` not `import scarab` in python (which means we should call the namespace py_scarab in the source file's filename etc.).

If they don't agree then the build completes but imports fail because python doesn't know how to find the init from the binary.