### PR TITLE
Feature/py docs

### DIFF
--- a/library/python/param_array_pybind.hh
+++ b/library/python/param_array_pybind.hh
@@ -31,45 +31,68 @@ namespace scarab_pybind
             .def( "empty", &scarab::param_array::empty,
                     "True if the length is zero" )
 
-            .def( "resize", &scarab::param_array::resize,
+            .def( "resize", &scarab::param_array::resize, pybind11::arg( "size" )
                     "Sets the size of the array; if smaller than the current size, the extra elements are deleted" )
 
-            .def( "assign", (void (scarab::param_array::*)(unsigned, const scarab::param&)) &scarab::param_array::assign,
-                    "Add a param object to the specified index in a array" )
+            .def( "assign",
+                    (void (scarab::param_array::*)(unsigned, const scarab::param&)) &scarab::param_array::assign,
+                    pybind11::arg( "index" ),
+                    pybind11::arg( "value" ),
+                    "Add a param object [value] to the specified [index] in a array" )
 
             // Get value of the parameter, bringing along the default value
-            .def( "get_value", (bool (scarab::param_array::*)(unsigned, bool) const) &scarab::param_array::get_value<bool>,
-                    "Get parameter array value as a bool" )
-            .def( "get_value", (unsigned (scarab::param_array::*)(unsigned, unsigned) const) &scarab::param_array::get_value<uint>,
-                    "Get parameter array value as an unsigned integer" )
-            .def( "get_value", (int (scarab::param_array::*)(unsigned, int) const) &scarab::param_array::get_value<int>,
-                    "Get parameter array value as a signed integer" )
-            .def( "get_value", (double (scarab::param_array::*)(unsigned, double) const) &scarab::param_array::get_value<double>,
-                    "Get parameter array value as a float" )
-            .def( "get_value", (std::string (scarab::param_array::*)(unsigned, const std::string& ) const) &scarab::param_array::get_value,
-                    "Get parameter array value as a string" )
+            .def( "get_value",
+                    (bool (scarab::param_array::*)(unsigned, bool) const) &scarab::param_array::get_value<bool>,
+                    pybind11::arg( "index" ),
+                    pybind11::arg( "default" ),
+                    "Get boolean parameter array value at index, or return provided value if out of index range" )
+            .def( "get_value",
+                    (unsigned (scarab::param_array::*)(unsigned, unsigned) const) &scarab::param_array::get_value<uint>,
+                    pybind11::arg( "index" ),
+                    pybind11::arg( "default" ),
+                    "Get integer parameter array value at index, or return provided value if out of index range" )
+            .def( "get_value",
+                    (int (scarab::param_array::*)(unsigned, int) const) &scarab::param_array::get_value<int>,
+                    pybind11::arg( "index" ),
+                    pybind11::arg( "default" ),
+                    "Get signed integer parameter array value at index, or return provided value if out of index range" )
+            .def( "get_value",
+                    (double (scarab::param_array::*)(unsigned, double) const) &scarab::param_array::get_value<double>,
+                    pybind11::arg( "index" ),
+                    pybind11::arg( "default" ),
+                    "Get float parameter array value at index, or return provided value if out of index range" )
+            .def( "get_value",
+                    (std::string (scarab::param_array::*)(unsigned, const std::string& ) const) &scarab::param_array::get_value,
+                    pybind11::arg( "index" ),
+                    pybind11::arg( "default" ),
+                    "Get string parameter array value at index, or return provided value if out of index range" )
 
-            .def( "push_back", (void (scarab::param_array::*)(const scarab::param&)) &scarab::param_array::push_back, "add a param object to the end of the array")
-            //.def( "push_back", (void (scarab::param_array::*)(scarab::param&)) &scarab::param_array::push_back, "add a param object to the end of the array")
-            .def( "push_front", (void (scarab::param_array::*)(const scarab::param&)) &scarab::param_array::push_front, "add a param object to the end of the array")
-            //.def( "push_front", (void (scarab::param_array::*)(scarab::param&)) &scarab::param_array::push_front, "add a param object to the end of the array")
+            .def( "push_back",
+                    (void (scarab::param_array::*)(const scarab::param&)) &scarab::param_array::push_back,
+                    pybind11::arg( "value" )
+                    "add a param object to the end of the array")
+            .def( "push_front",
+                    (void (scarab::param_array::*)(const scarab::param&)) &scarab::param_array::push_front,
+                    pybind11::arg( "value" )
+                    "add a param object to the end of the array")
 
-            .def( "append", &scarab::param_array::append )
-            .def( "merge", &scarab::param_array::merge )
-            .def( "erase", &scarab::param_array::erase )
-            .def( "remove", &scarab::param_array::remove )
-            .def( "clear", &scarab::param_array::clear )
-
-            /*
-            .def( "to_python", [](const scarab::param_array& an_obj){
-                        pybind11::list to_return;
-                        for (scarab::param_array_const_iterator an_item=an_obj.begin(); an_item != an_obj.end(); ++an_item)
-                        {
-                            to_return.append( pybind11::cast((*an_item)()).to_python() );
-                        }
-                        return to_return;
-                    } )
-            */
+            .def( "append",
+                    &scarab::param_array::append,
+                    pybind11::arg( "array" ),
+                    "adds all elements of a param_array to the end of this" )
+            .def( "merge",
+                    &scarab::param_array::merge,
+                    pybind11::arg( "array" ),
+                    "merges provided param_array, effectively replacing the current array")
+            .def( "erase",
+                    &scarab::param_array::erase,
+                    pybind11::arg( "index" ),
+                    "eliminates the value at a position in the array" )
+            .def( "remove",
+                    &scarab::param_array::remove,
+                    pybind11::arg( "index" ),
+                    "returns the param_value at the provided index and removes it from the array" )
+            .def( "clear", &scarab::param_array::clear, "erase all contents and resize to 0" )
 
             ;
     }

--- a/library/python/param_array_pybind.hh
+++ b/library/python/param_array_pybind.hh
@@ -15,7 +15,7 @@ namespace scarab_pybind
     void export_param_array( pybind11::module& mod )
     {
         // param_array
-        pybind11::class_< scarab::param_array, scarab::param >( mod, "ParamArray" )
+        pybind11::class_< scarab::param_array, scarab::param >( mod, "ParamArray", "param data structure object for holding an ordered sequence of objects" )
             .def( pybind11::init< >() )
             .def( "__str__", &scarab::param_array::to_string )
             .def( "__len__", &scarab::param_array::size,
@@ -31,7 +31,7 @@ namespace scarab_pybind
             .def( "empty", &scarab::param_array::empty,
                     "True if the length is zero" )
 
-            .def( "resize", &scarab::param_array::resize, pybind11::arg( "size" )
+            .def( "resize", &scarab::param_array::resize, pybind11::arg( "size" ),
                     "Sets the size of the array; if smaller than the current size, the extra elements are deleted" )
 
             .def( "assign",
@@ -69,11 +69,11 @@ namespace scarab_pybind
 
             .def( "push_back",
                     (void (scarab::param_array::*)(const scarab::param&)) &scarab::param_array::push_back,
-                    pybind11::arg( "value" )
+                    pybind11::arg( "value" ),
                     "add a param object to the end of the array")
             .def( "push_front",
                     (void (scarab::param_array::*)(const scarab::param&)) &scarab::param_array::push_front,
-                    pybind11::arg( "value" )
+                    pybind11::arg( "value" ),
                     "add a param object to the end of the array")
 
             .def( "append",

--- a/library/python/param_node_pybind.hh
+++ b/library/python/param_node_pybind.hh
@@ -13,7 +13,7 @@ namespace scarab_pybind
     void export_param_node( pybind11::module& mod )
     {
         // param_node
-        pybind11::class_< scarab::param_node, scarab::param >( mod, "ParamNode" )
+        pybind11::class_< scarab::param_node, scarab::param >( mod, "ParamNode", "param data structure object for holding a collection of object indexable by string keys" )
             .def( pybind11::init< >() )
 
             .def( "__str__", &scarab::param_node::to_string )
@@ -32,32 +32,42 @@ namespace scarab_pybind
 
             //TODO: has_subset()
 
-            .def( "empty", &scarab::param_node::empty )
+            .def( "empty", &scarab::param_node::empty, "returns whether the map container is empty")
 
-            .def( "add", (bool (scarab::param_node::*)(const std::string&, const scarab::param&)) &scarab::param_node::add,
-                    "Add a param object to a node")
-
-            //TODO: remove this; it's not part of the actual param API
-            .def( "at", (scarab::param& (scarab::param_node::*)(const std::string&)) &scarab::param_node::operator[],
-                    "Get the param object for a given key" )
+            .def( "add",
+                    (bool (scarab::param_node::*)(const std::string&, const scarab::param&)) &scarab::param_node::add,
+                    pybind11::arg( "key" ),
+                    pybind11::arg( "value" ),
+                    "Add a param object to a node at a particular key")
 
             // Get value of the parameter, bringing along the default value
-            .def( "get_value", (bool (scarab::param_node::*)(const std::string&, bool) const) &scarab::param_node::get_value<bool>,
-                    "Get parameter node value as a bool" )
-            .def( "get_value", (unsigned (scarab::param_node::*)(const std::string&, unsigned) const) &scarab::param_node::get_value<uint>,
-                    "Get parameter node value as an unsigned integer" )
-            .def( "get_value", (int (scarab::param_node::*)(const std::string&, int) const) &scarab::param_node::get_value<int>,
-                    "Get parameter node value as a signed integer" )
-            .def( "get_value", (double (scarab::param_node::*)(const std::string&, double) const) &scarab::param_node::get_value<double>,
-                    "Get parameter node value as a float" )
-            .def( "get_value", (std::string (scarab::param_node::*)(const std::string&, const std::string& ) const) &scarab::param_node::get_value,
-                    "Get parameter node value as a string" )
-
-            //TODO: replace()
+            .def( "get_value",
+                    (bool (scarab::param_node::*)(const std::string&, bool) const) &scarab::param_node::get_value<bool>,
+                    pybind11::arg( "key" ),
+                    pybind11::arg( "default" ),
+                    "Get parameter node value at [key] or return [default] (as a bool)" )
+            .def( "get_value",
+                    (unsigned (scarab::param_node::*)(const std::string&, unsigned) const) &scarab::param_node::get_value<uint>,
+                    pybind11::arg( "key" ),
+                    pybind11::arg( "default" ),
+                    "Get parameter node value at [key] or return [default] (as an unsigned integer)" )
+            .def( "get_value",
+                    (int (scarab::param_node::*)(const std::string&, int) const) &scarab::param_node::get_value<int>,
+                    pybind11::arg( "key" ),
+                    pybind11::arg( "default" ),
+                    "Get parameter node value at [key] or return [default] (as a signed integer)" )
+            .def( "get_value",
+                    (double (scarab::param_node::*)(const std::string&, double) const) &scarab::param_node::get_value<double>,
+                    pybind11::arg( "key" ),
+                    pybind11::arg( "default" ),
+                    "Get parameter node value at [key] or return [default] (as a float)" )
+            .def( "get_value",
+                    (std::string (scarab::param_node::*)(const std::string&, const std::string& ) const) &scarab::param_node::get_value,
+                    pybind11::arg( "key" ),
+                    pybind11::arg( "default" ),
+                    "Get parameter node value at [key] or return [default] (as a string)" )
 
             //TODO: merge(), erase(), remove(), clear()
-
-            //TODO: iterators
 
 
             ;

--- a/library/python/param_node_pybind.hh
+++ b/library/python/param_node_pybind.hh
@@ -25,10 +25,10 @@ namespace scarab_pybind
             .def( "__iter__", [](const scarab::param_node& an_obj){ return pybind11::make_iterator(an_obj.begin(), an_obj.end()); },
                     pybind11::keep_alive<0, 1>() /* keep object alive while the iterator exists */ )
 
-            .def( "count", &scarab::param_node::count )
-
-            .def( "is_null", &scarab::param_node::is_null )
-            .def( "is_node", &scarab::param_node::is_node )
+            .def( "count",
+                    &scarab::param_node::count,
+                    pybind11::arg( "key" ),
+                    "returns the number of occurances of provided key" )
 
             //TODO: has_subset()
 

--- a/library/python/param_pybind.hh
+++ b/library/python/param_pybind.hh
@@ -116,14 +116,6 @@ namespace scarab_pybind
             .def( "__str__", &scarab::param::to_string )
             .def( "__call__", (scarab::param_value& (scarab::param::*)()) &scarab::param::operator(),
                     pybind11::return_value_policy::reference_internal )
-            /* TODO doesn't python automatically upcast to an ParamArray or ParamNode? (In which case we don't need these here)...
-                    if we do need them here then we shold add the __setitem__ listed below
-            .def( "__getitem__", (scarab::param& (scarab::param::*)(unsigned)) &scarab::param::operator[],
-                    pybind11::return_value_policy::reference_internal )
-            .def( "__getitem__", (scarab::param& (scarab::param::*)(const std::string&)) &scarab::param::operator[],
-                    pybind11::return_value_policy::reference_internal )
-            */
-            //TODO: do we need __setitem__?
 
             .def( "is_null", &scarab::param::is_null, "return whether the param object is an empty param type" )
             .def( "is_node", &scarab::param::is_node, "return whether the param object is a ParamNode" )

--- a/library/python/param_pybind.hh
+++ b/library/python/param_pybind.hh
@@ -97,7 +97,6 @@ namespace scarab_pybind
             pybind11::dict to_return;
             for (scarab::param_node_const_iterator an_item=this_node.begin(); an_item != this_node.end(); ++an_item)
             {
-                //TODO how do I modify the contents of a pybind11::dict here... the following still fails
                 to_return[ an_item.name().c_str() ] = to_python( *an_item );
             }
             return to_return;
@@ -110,7 +109,7 @@ namespace scarab_pybind
         mod.def( "to_param", &to_param, "Convert native python types to a param structure." );
 
         // param
-        pybind11::class_< scarab::param >( mod, "Param" )
+        pybind11::class_< scarab::param >( mod, "Param", "param data structure base class and null object" )
             .def( pybind11::init< >() )
             .def( pybind11::init< scarab::param_value >() )
 
@@ -123,19 +122,25 @@ namespace scarab_pybind
                     pybind11::return_value_policy::reference_internal )
             //TODO: do we need __setitem__?
 
-            .def( "is_null", &scarab::param::is_null )
-            .def( "is_node", &scarab::param::is_node )
-            .def( "is_array", &scarab::param::is_array )
-            .def( "is_value", &scarab::param::is_value )
+            .def( "is_null", &scarab::param::is_null, "return whether the param object is an empty param type" )
+            .def( "is_node", &scarab::param::is_node, "return whether the param object is a ParamNode" )
+            .def( "is_array", &scarab::param::is_array, "return whether the param object is a ParamArray" )
+            .def( "is_value", &scarab::param::is_value, "return whether the param object is a ParamValue" )
 
-            .def( "as_array", (scarab::param_array& (scarab::param::*)()) &scarab::param::as_array,
-                    pybind11::return_value_policy::reference_internal )
-            .def( "as_node", (scarab::param_node& (scarab::param::*)()) &scarab::param::as_node,
-                    pybind11::return_value_policy::reference_internal )
-            .def( "as_value", (scarab::param_value& (scarab::param::*)()) &scarab::param::as_value,
-                    pybind11::return_value_policy::reference_internal )
+            .def( "as_array",
+                    (scarab::param_array& (scarab::param::*)()) &scarab::param::as_array,
+                    pybind11::return_value_policy::reference_internal,
+                    "returns Param object as a ParamArray" )
+            .def( "as_node",
+                    (scarab::param_node& (scarab::param::*)()) &scarab::param::as_node,
+                    pybind11::return_value_policy::reference_internal,
+                    "returns Param object as ParamNode" )
+            .def( "as_value",
+                    (scarab::param_value& (scarab::param::*)()) &scarab::param::as_value,
+                    pybind11::return_value_policy::reference_internal,
+                    "returns Param object as ParamValue" )
 
-            .def( "to_python", &to_python )
+            .def( "to_python", &to_python, "recursively converts param object to native python data structure" )
 
             //TODO: has_subset()
 

--- a/library/python/param_pybind.hh
+++ b/library/python/param_pybind.hh
@@ -116,10 +116,13 @@ namespace scarab_pybind
             .def( "__str__", &scarab::param::to_string )
             .def( "__call__", (scarab::param_value& (scarab::param::*)()) &scarab::param::operator(),
                     pybind11::return_value_policy::reference_internal )
+            /* TODO doesn't python automatically upcast to an ParamArray or ParamNode? (In which case we don't need these here)...
+                    if we do need them here then we shold add the __setitem__ listed below
             .def( "__getitem__", (scarab::param& (scarab::param::*)(unsigned)) &scarab::param::operator[],
                     pybind11::return_value_policy::reference_internal )
             .def( "__getitem__", (scarab::param& (scarab::param::*)(const std::string&)) &scarab::param::operator[],
                     pybind11::return_value_policy::reference_internal )
+            */
             //TODO: do we need __setitem__?
 
             .def( "is_null", &scarab::param::is_null, "return whether the param object is an empty param type" )

--- a/library/python/param_value_pybind.hh
+++ b/library/python/param_value_pybind.hh
@@ -14,7 +14,7 @@ namespace scarab_pybind
     void export_param_value( pybind11::module& mod )
     {
         // param_value
-        pybind11::class_< scarab::param_value, scarab::param >( mod, "ParamValue" )
+        pybind11::class_< scarab::param_value, scarab::param >( mod, "ParamValue", "param data structure object for holding a single value" )
             // initialization overloads by type
             .def( pybind11::init< bool >() )
             .def( pybind11::init< unsigned >() )
@@ -68,17 +68,6 @@ namespace scarab_pybind
 
             //TODO: empty(), clear(), has_subset()
 
-            /*
-            .def( "to_python", [](const scarab::param_value& an_obj){
-                        pybind11::object to_return;
-                        if (an_obj.is_bool()) to_return =  pybind11::cast(an_obj.as_bool());
-                        else if (an_obj.is_uint()) to_return = pybind11::cast(an_obj.as_uint());
-                        else if (an_obj.is_int()) to_return = pybind11::cast(an_obj.as_int());
-                        else if (an_obj.is_double()) to_return = pybind11::cast(an_obj.as_double());
-                        else if (an_obj.is_string()) to_return = pybind11::cast(an_obj.as_string());
-                        return to_return;
-                    } )
-            */
             ;
     }
 


### PR DESCRIPTION
Added lots of doc strings and `pybind11::arg` to bindings to improve interactive UX (and in anticipation of future automatic docs via sphynx).

Also tried to address commented code blocks (actually remove things that were commented out and aren't expected to go back in, updated resolved `//TODO` elements.

~Prior to merge, should resolve `__getitem__` and `__setitem__` in binding for param.~