### PR TITLE
adding greater-than operator

### DIFF
--- a/library/utility/version_base.cc
+++ b/library/utility/version_base.cc
@@ -131,7 +131,9 @@ namespace scarab
     bool version_semantic::operator<( const version_semantic& a_other )
     {
         if( f_major_ver < a_other.f_major_ver ) return true;
+        if( f_major_ver > a_other.f_major_ver ) return false;
         if( f_minor_ver < a_other.f_minor_ver ) return true;
+        if( f_minor_ver > a_other.f_minor_ver ) return false;
         if( f_patch_ver < a_other.f_patch_ver ) return true;
         return false;
     }
@@ -141,6 +143,16 @@ namespace scarab
         return f_major_ver == a_other.f_major_ver &&
                f_minor_ver == a_other.f_minor_ver &&
                f_patch_ver == a_other.f_patch_ver;
+    }
+
+    bool version_semantic::operator>( const version_semantic& a_other )
+    {
+        if( f_major_ver > a_other.f_major_ver ) return true;
+        if( f_major_ver < a_other.f_major_ver ) return false;
+        if( f_minor_ver > a_other.f_minor_ver ) return true;
+        if( f_minor_ver < a_other.f_minor_ver ) return false;
+        if( f_patch_ver > a_other.f_patch_ver ) return true;
+        return false;
     }
 
     bool version_semantic::parse( const std::string& a_ver )

--- a/library/utility/version_base.hh
+++ b/library/utility/version_base.hh
@@ -55,6 +55,8 @@ namespace scarab
             bool operator<( const version_semantic& a_other );
             /// Equality operator to compare version information only
             bool operator==( const version_semantic& a_other );
+            /// Greater-than operator to compare version information only
+            bool operator>( const version_semantic& a_other );
 
             virtual unsigned major_version() const;
             virtual unsigned minor_version() const;


### PR DESCRIPTION
Fixed the less-than operator (should only fall back to lower parts of the version if equal, not just not lt).

Added greater-than operator: (was this left out intentionally? ie does c++ fall back to not operator== and not operator< for operator> if there is no operator>?)?

Similarly, is it better to implement it as logic on the content, or to use the above with the other existing operators? (does it matter?)