### PR TITLE
Feature/config modifier

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -140,6 +140,7 @@ include_directories( BEFORE
     ${PROJECT_SOURCE_DIR}/utility
     ${PROJECT_SOURCE_DIR}/logger
     ${PROJECT_SOURCE_DIR}/version
+    ${PROJECT_SOURCE_DIR}/modifier
 )
 
 ##########
@@ -154,6 +155,7 @@ include_directories( BEFORE
 add_subdirectory( utility )
 add_subdirectory( version )
 add_subdirectory( logger )
+add_subdirectory( modifier )
 
 if( Scarab_BUILD_PARAM )
     include_directories( BEFORE ${PROJECT_SOURCE_DIR}/param )

--- a/library/cli/application.cc
+++ b/library/cli/application.cc
@@ -13,6 +13,9 @@
 #include "nonoption_parser.hh"
 #include "param_codec.hh"
 #include "version_wrapper.hh"
+#include "null_modifier.hh"
+
+#include <list>
 
 using std::string;
 
@@ -99,6 +102,8 @@ namespace scarab
 
         do_config_stage_4();
 
+        do_config_stage_5();
+
         LPROG( applog, "Final configuration:\n" << f_master_config );
         LPROG( applog, "Ordered args:\n" << f_nonoption_ord_args );
     }
@@ -148,6 +153,18 @@ namespace scarab
         std::for_each( f_app_option_holders.begin(), f_app_option_holders.end(),
                        [this]( std::shared_ptr< app_option_holder > a_ptr ){ a_ptr->add_to_app_options(f_app_options); } );
         f_master_config.merge( f_app_options );
+        return;
+    }
+
+    void main_app::do_config_stage_5()
+    {
+        // fifth configuration stage: additional modification of param_node  (variable substitution, etc.)
+        std::list<std::shared_ptr< modifier >> modifiers;
+        modifiers.push_back( std::make_shared< null_modifier >() ); //add items to chain
+        modifiers.push_back( std::make_shared < null_modifier >() );
+
+        std::for_each(modifiers.begin(), modifiers.end(),
+                [this](std::shared_ptr< modifier> a_ptr){ a_ptr->modify(f_master_config);} );
         return;
     }
 

--- a/library/cli/application.cc
+++ b/library/cli/application.cc
@@ -13,6 +13,8 @@
 #include "nonoption_parser.hh"
 #include "param_codec.hh"
 #include "version_wrapper.hh"
+
+#include "env_substitute.hh"
 #include "null_modifier.hh"
 
 #include <list>
@@ -160,8 +162,9 @@ namespace scarab
     {
         // fifth configuration stage: additional modification of param_node  (variable substitution, etc.)
         std::list<std::shared_ptr< modifier >> modifiers;
-        modifiers.push_back( std::make_shared< null_modifier >() ); //add items to chain
-        modifiers.push_back( std::make_shared < null_modifier >() );
+        //add items to chain
+        modifiers.push_back( std::make_shared< null_modifier >() );
+        modifiers.push_back( std::make_shared< env_substitute >() );
 
         std::for_each(modifiers.begin(), modifiers.end(),
                 [this](std::shared_ptr< modifier> a_ptr){ a_ptr->modify(f_master_config);} );

--- a/library/cli/application.hh
+++ b/library/cli/application.hh
@@ -270,6 +270,8 @@ namespace scarab
             virtual void do_config_stage_3();
             /// Load the application-specific options
             virtual void do_config_stage_4();
+            /// Load the modifiers
+            virtual void do_config_stage_5();
 
             void set_version( scarab::version_semantic_ptr_t a_ver );
 

--- a/library/modifier/CMakeLists.txt
+++ b/library/modifier/CMakeLists.txt
@@ -1,0 +1,15 @@
+# CMakeLists.txt for Scarab/library/modifier
+# Author: N. Buzinsky
+# Created: Feb 12, 2020
+
+set( dir ${CMAKE_CURRENT_SOURCE_DIR} )
+
+set( Scarab_HEADERS ${Scarab_HEADERS}
+    ${dir}/modifier.hh
+    ${dir}/null_modifier.hh
+    PARENT_SCOPE )
+
+set( Scarab_SOURCES ${Scarab_SOURCES}
+    ${dir}/modifier.cc
+    ${dir}/null_modifier.cc
+    PARENT_SCOPE )

--- a/library/modifier/CMakeLists.txt
+++ b/library/modifier/CMakeLists.txt
@@ -7,9 +7,11 @@ set( dir ${CMAKE_CURRENT_SOURCE_DIR} )
 set( Scarab_HEADERS ${Scarab_HEADERS}
     ${dir}/modifier.hh
     ${dir}/null_modifier.hh
+    ${dir}/env_substitute.hh
     PARENT_SCOPE )
 
 set( Scarab_SOURCES ${Scarab_SOURCES}
     ${dir}/modifier.cc
     ${dir}/null_modifier.cc
+    ${dir}/env_substitute.cc
     PARENT_SCOPE )

--- a/library/modifier/env_substitute.cc
+++ b/library/modifier/env_substitute.cc
@@ -47,8 +47,11 @@ namespace scarab
             auto &a_param_value = a_param->as_value();
             if(a_param_value.is_string())
             {
-                std::string old_value = a_param_value.to_string();
-                std::string new_value = substitute_environmentals(old_value);
+                const std::string old_value = a_param_value.to_string();
+                std::string new_value = old_value;
+
+                if(valid_env_name(old_value)) new_value = substitute_environmentals(old_value);
+
                 if(old_value != new_value)
                 {
                     LDEBUG( mm2log, "Substituting value:  " << old_value <<"  -->  " <<new_value);
@@ -61,21 +64,19 @@ namespace scarab
     std::string env_substitute::substitute_environmentals(std::string old_value) const
     {
         std::string new_value = old_value;
-        if(valid_env_name(old_value))
-        {
-            old_value.erase(0,1); //erase leading dollar sign
-            LDEBUG( mm2log, "Found environmental variable in config: " << old_value);
-            char *p  = std::getenv(old_value.c_str());
+        old_value.erase(0,1); //erase leading dollar sign
+        LDEBUG( mm2log, "Found environmental variable in config: " << old_value);
+        char *p  = std::getenv(old_value.c_str());
 
-            if(!p)
-            {
-                LERROR( mm2log, "Variable $" << old_value << " in config not in environment! Leaving as string (not recommended)!");
-            }
-            else
-            {
-                new_value = std::string(p);
-            }
+        if(!p)
+        {
+            LERROR( mm2log, "Variable $" << old_value << " in config not in environment! Leaving as string (not recommended)!");
         }
+        else
+        {
+            new_value = std::string(p);
+        }
+
         return new_value;
     }
 

--- a/library/modifier/env_substitute.cc
+++ b/library/modifier/env_substitute.cc
@@ -54,7 +54,6 @@ namespace scarab
                     LDEBUG( mm2log, "Substituting value:  " << old_value <<"  -->  " <<new_value);
                     a_param_value.set(new_value);
                 }
-
             }
         }
     }
@@ -62,7 +61,6 @@ namespace scarab
     std::string env_substitute::substitute_environmentals(std::string old_value) const
     {
         std::string new_value = old_value;
-
         if(valid_env_name(old_value))
         {
             old_value.erase(0,1); //erase leading dollar sign
@@ -72,12 +70,12 @@ namespace scarab
             if(!p)
             {
                 LERROR( mm2log, "Variable $" << old_value << " in config not in environment! Leaving as string (not recommended)!");
-                return new_value;
             }
-
-            new_value = std::string(p);
+            else
+            {
+                new_value = std::string(p);
+            }
         }
-
         return new_value;
     }
 

--- a/library/modifier/env_substitute.cc
+++ b/library/modifier/env_substitute.cc
@@ -1,0 +1,61 @@
+/*
+ * env_substitute.cc
+ *
+ *  Created on: Feb 19, 2020
+ *      Author: N. Buzinsky
+ */
+
+#define SCARAB_API_EXPORTS
+
+#include "env_substitute.hh"
+#include "logger.hh"
+
+#include <iostream>
+#include <cstdlib>
+#include <regex>
+
+namespace scarab
+{
+    LOGGER( mm2log, "env_substitute" );
+
+    void env_substitute::modify(param_node &a_config) //use better type checking?
+    {
+        for( auto it = a_config.begin(); it != a_config.end(); ++it )
+        {
+            std::string old_value = (*it).to_string();
+            std::string new_value = substitute_environmentals(old_value);
+            if( new_value != old_value)
+                a_config.replace(it.name(),new_value);
+        }
+        return;
+    }
+    
+    std::string env_substitute::substitute_environmentals(std::string config_field) const
+    {
+        std::string new_value = config_field;
+
+        if(valid_env_name(config_field))
+        {
+            config_field.erase(0,1); //erase leading dollar sign
+            LDEBUG( mm2log, "Found environmental variable in config: " << config_field);
+            char *p  = std::getenv(config_field.c_str());
+
+            if(!p)
+            {
+                LERROR( mm2log, "Variable $" << config_field << " in config not in environment! Leaving as string (not recommended)!");
+                return new_value;
+            }
+
+            new_value = std::string(p);
+        }
+
+        return new_value;
+    }
+
+    bool env_substitute::valid_env_name(const std::string& env_name) const
+    {
+        const std::regex re{"^\\$DRIPLINE_[A-Z0-9][A-Z0-9_]*$"};
+        return std::regex_match(env_name, re);
+    }
+
+} /* namespace scarab */

--- a/library/modifier/env_substitute.hh
+++ b/library/modifier/env_substitute.hh
@@ -1,0 +1,30 @@
+/*
+ * env_substitute.hh
+ *
+ *  Created on: Feb 19, 2020
+ *      Author: N. Buzinsky
+ */
+
+#ifndef SCARAB_ENV_SUBSTITUTE_HH_
+#define SCARAB_ENV_SUBSTITUTE_HH_
+
+#include "modifier.hh"
+
+#include <string>
+
+namespace scarab
+{
+
+    class SCARAB_API env_substitute : public modifier
+    {
+        public:
+            void modify(param_node &a_config);
+
+        private:
+            std::string substitute_environmentals(std::string config_field) const;
+            bool valid_env_name(const std::string& env_name) const;
+    };
+
+} /* namespace scarab */
+
+#endif /* SCARAB_ENV_SUBSTITUTE_HH_ */

--- a/library/modifier/env_substitute.hh
+++ b/library/modifier/env_substitute.hh
@@ -14,7 +14,6 @@
 
 namespace scarab
 {
-
     class SCARAB_API env_substitute : public modifier
     {
         public:
@@ -25,7 +24,6 @@ namespace scarab
             bool valid_env_name(const std::string& env_name) const;
             template <class param_iterator>
             void recurse_param(param_iterator &a_param);
-
     };
 
 } /* namespace scarab */

--- a/library/modifier/env_substitute.hh
+++ b/library/modifier/env_substitute.hh
@@ -23,6 +23,9 @@ namespace scarab
         private:
             std::string substitute_environmentals(std::string config_field) const;
             bool valid_env_name(const std::string& env_name) const;
+            template <class param_iterator>
+            void recurse_param(param_iterator &a_param);
+
     };
 
 } /* namespace scarab */

--- a/library/modifier/modifier.cc
+++ b/library/modifier/modifier.cc
@@ -1,0 +1,27 @@
+/*
+ * modifier.cc
+ *
+ *  Created on: Feb 12, 2020
+ *      Author: N. Buzinsky
+ */
+
+#define SCARAB_API_EXPORTS
+
+#include "logger.hh"
+
+#include "modifier.hh"
+
+
+namespace scarab
+{
+    //LOGGER( mdlog, "modifier" );
+
+    modifier::modifier()
+    {
+    }
+
+    modifier::~modifier()
+    {
+    }
+
+} /* namespace scarab */

--- a/library/modifier/modifier.cc
+++ b/library/modifier/modifier.cc
@@ -7,15 +7,11 @@
 
 #define SCARAB_API_EXPORTS
 
-#include "logger.hh"
-
 #include "modifier.hh"
 
 
 namespace scarab
 {
-    //LOGGER( mdlog, "modifier" );
-
     modifier::modifier()
     {
     }

--- a/library/modifier/modifier.hh
+++ b/library/modifier/modifier.hh
@@ -1,0 +1,29 @@
+/*
+ * modifier.hh
+ *
+ *  Created on: Feb 12, 2019
+ *      Author: N. Buzinsky
+ */
+
+#ifndef SCARAB_MODIFIER_HH_
+#define SCARAB_MODIFIER_HH_
+
+#include "param_node.hh"
+
+namespace scarab
+{
+
+    class SCARAB_API modifier
+    {
+        public:
+            modifier();
+            ~modifier();
+
+        public:
+            virtual void modify(param_node &a_config) = 0;
+
+    };
+
+} /* namespace scarab */
+
+#endif /* SCARAB_MODIFIER_HH_ */

--- a/library/modifier/modifier.hh
+++ b/library/modifier/modifier.hh
@@ -1,7 +1,7 @@
 /*
  * modifier.hh
  *
- *  Created on: Feb 12, 2019
+ *  Created on: Feb 12, 2020
  *      Author: N. Buzinsky
  */
 

--- a/library/modifier/null_modifier.cc
+++ b/library/modifier/null_modifier.cc
@@ -1,0 +1,25 @@
+/*
+ * null_modifier.cc
+ *
+ *  Created on: Feb 12, 2020
+ *      Author: N. Buzinsky
+ */
+
+#define SCARAB_API_EXPORTS
+
+#include "null_modifier.hh"
+#include <iostream>
+
+
+namespace scarab
+{
+    //LOGGER( mmlog, "null_modifier" );
+
+    void null_modifier::modify(param_node &a_config)
+    {
+        //LDEBUG( mmlog, "Complex modifications going on ....." );
+        std::cout<<"Complex modifications going on ....."<<std::endl;
+        return;
+    }
+
+} /* namespace scarab */

--- a/library/modifier/null_modifier.cc
+++ b/library/modifier/null_modifier.cc
@@ -8,17 +8,15 @@
 #define SCARAB_API_EXPORTS
 
 #include "null_modifier.hh"
-#include <iostream>
-
+#include "logger.hh"
 
 namespace scarab
 {
-    //LOGGER( mmlog, "null_modifier" );
+    LOGGER( mmlog, "null_modifier" );
 
     void null_modifier::modify(param_node &a_config)
     {
-        //LDEBUG( mmlog, "Complex modifications going on ....." );
-        std::cout<<"Complex modifications going on ....."<<std::endl;
+        LDEBUG( mmlog, "Complex modifications going on ....." );
         return;
     }
 

--- a/library/modifier/null_modifier.hh
+++ b/library/modifier/null_modifier.hh
@@ -1,7 +1,7 @@
 /*
  * null_modifier.hh
  *
- *  Created on: Feb 12, 2019
+ *  Created on: Feb 12, 2020
  *      Author: N. Buzinsky
  */
 

--- a/library/modifier/null_modifier.hh
+++ b/library/modifier/null_modifier.hh
@@ -1,0 +1,24 @@
+/*
+ * null_modifier.hh
+ *
+ *  Created on: Feb 12, 2019
+ *      Author: N. Buzinsky
+ */
+
+#ifndef SCARAB_NULL_MODIFIER_HH_
+#define SCARAB_NULL_MODIFIER_HH_
+
+#include "modifier.hh"
+
+namespace scarab
+{
+
+    class SCARAB_API null_modifier : public modifier
+    {
+        public:
+            void modify(param_node &a_config);
+    };
+
+} /* namespace scarab */
+
+#endif /* SCARAB__NULL_MODIFIER_HH_ */


### PR DESCRIPTION
This branch adds the modifier base class/ derived classes that directly alter the master_config object directly. 
So far I've implemented & tested the trivial modifier (no changes to config), and an environmental variable substitution modifier. 

I was still going to try to add local variable substitution as another derived class. E.g. substituting name_1 in the config:
```
$name_1 : "blah blah" 
   .
   . 
   .
   key: "$name_1"

```
It may be a good idea to encapsulate the modifier instances/ list in another class, to better hide it from the application class: not sure here.

I did want to start discussion on the variable substitution syntax. My plan was to have things of the form `$DRIPLINE_...` for environmental variable substitution (specifically the regex pattern right now is `"^\\$DRIPLINE_[A-Z0-9][A-Z0-9_]*$"`

For local variable substitution, I was going to pick up similar strings, without the DRIPLINE: `"^\\$[A-Z][A-Z0-9_]*$"`.

Though these make sense to me, and is often what I enforce on myself, if we don't communicate clearly eg. lowercase letters won't work somewhere in documentation/ errors handling, someone could end up banging their head why the regex isn't picking up their environmental/ local variable.