### PR TITLE
Allow multiple calls to pbuilder_component_install_and_export for executables

### DIFF
--- a/cmake/PackageBuilderMacros.cmake
+++ b/cmake/PackageBuilderMacros.cmake
@@ -329,7 +329,8 @@ function( pbuilder_component_install_and_export )
 
         # make targets available at build time
         #message( STATUS "******* build-time exe targets file: ${PROJECT_BINARY_DIR}/${PROJECT_NAME}${INSERT_COMPONENT}_Targets.cmake" )
-        export( TARGETS ${CIE_EXETARGETS} 
+        export( TARGETS ${CIE_EXETARGETS}
+            APPEND
             FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}${INSERT_COMPONENT}_Targets.cmake
         )
         


### PR DESCRIPTION
When there are several executables from various places inside a single project, scarab package builder seems to have some difficulties to install all of them.
Say we have a folder and CMakeList for a set of main executables and an additional folder and CMakeLists with test executables.
Currently, if there is a pbuilder_component_install_and_export in each CMakeLists the cmake step returns:
```
-- Targets are: MakeAdditiveRF;MakeRF
CMake Error at library/externals/scarab/cmake/PackageBuilderMacros.cmake:333 (export):
  export command already specified for the file

    /Users/mguigue/Work/T2K/SourceTree/P-theta/build/PTheta_Executables_Targets.cmake

  Did you miss 'APPEND' keyword?
Call Stack (most recent call first):
  Tools/RF/CMakeLists.txt:30 (pbuilder_component_install_and_export)
```

This fix allows to 'append' additional executables to the list of executables to install.