### PR TITLE
Added fix so that pybind11 and cpython use consistent version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ endif( WIN32 )
 # Pybind11
 if( Scarab_BUILD_PYTHON )
     find_package( Python3 REQUIRED COMPONENTS Interpreter Development )
+    set(PYBIND11_PYTHON_VERSION ${Python3_VERSION} CACHE STRING "")
     find_package( pybind11 REQUIRED )
     #if( TARGET Python3::Python )
     #    message( STATUS "%%%%% Found Python::Python" )


### PR DESCRIPTION
Figured this out based on [this answer](https://stackoverflow.com/questions/62773837/cmake-and-pybind11-using-inconsistent-python-versions). Without this line in CMakeLists.txt pybind11 ends up using python3.7 even though cmake finds python3.8, which means python3.8 can't import the scarab shared library once it gets built