### PR TITLE
Fix default initialised path

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         fail-fast: [false]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
 
     steps:
 

--- a/cmake/PackageBuilder.cmake
+++ b/cmake/PackageBuilder.cmake
@@ -50,9 +50,7 @@ endif( "${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" )
 message( STATUS "Build type: ${CMAKE_BUILD_TYPE}" )
 
 # Setup the default install prefix
-# This gets set to the binary directory upon first configuring.
-# If the user changes the prefix, but leaves the flag OFF, then it will remain as the user specified.
-# If the user wants to reset the prefix to the default (i.e. the binary directory), then the flag should be set ON.
+# This gets set to the binary directory upon first configuring without overruling a user specification.
 if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
     set( CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR} CACHE PATH "Install prefix" FORCE )
 endif( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )

--- a/cmake/PackageBuilder.cmake
+++ b/cmake/PackageBuilder.cmake
@@ -53,13 +53,9 @@ message( STATUS "Build type: ${CMAKE_BUILD_TYPE}" )
 # This gets set to the binary directory upon first configuring.
 # If the user changes the prefix, but leaves the flag OFF, then it will remain as the user specified.
 # If the user wants to reset the prefix to the default (i.e. the binary directory), then the flag should be set ON.
-if( NOT DEFINED SET_INSTALL_PREFIX_TO_DEFAULT )
-    set( SET_INSTALL_PREFIX_TO_DEFAULT ON )
-endif( NOT DEFINED SET_INSTALL_PREFIX_TO_DEFAULT )
-if( SET_INSTALL_PREFIX_TO_DEFAULT )
+if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
     set( CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR} CACHE PATH "Install prefix" FORCE )
-    set( SET_INSTALL_PREFIX_TO_DEFAULT OFF CACHE BOOL "Reset default install path when when configuring" FORCE )
-endif( SET_INSTALL_PREFIX_TO_DEFAULT )
+endif( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
 
 # install subdirectories
 set( INCLUDE_INSTALL_SUBDIR "include/${PROJECT_NAME}" CACHE PATH "Install subdirectory for headers" )


### PR DESCRIPTION
A strange behaviour that arises is that if a user runs e.g. `cmake ../ -D CMAKE_INSTALL_PREFIX=../install`,
- the first time, this option is ignored as the `SET_INSTALL_PREFIX_TO_DEFAULT` is not defined and so the option is overridden and the software would be installed in the current binary folder.
- the second time we run this cmake command, the `SET_INSTALL_PREFIX_TO_DEFAULT` is defined and OFF, so the option is properly considered.
This can be checked by printing the variable before and after this paragraph.

Following the instructions here: https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html
one shouldn't need to run twice cmake to set the `CMAKE_INSTALL_PREFIX` right.
This MR should resolve https://github.com/project8/scarab/issues/24.
I think this feature you (@nsoblath ) describe in your last comment is this CMake variable (implemented at CMake 3.7)  